### PR TITLE
Do not attempt to call bytearray with None

### DIFF
--- a/mfrc522/simple_mfrc522.py
+++ b/mfrc522/simple_mfrc522.py
@@ -166,7 +166,7 @@ class SimpleMFRC522(object):
         
         status, uid, data = self.read_bytes(terminal_byte=terminal_byte)
         
-        if not status:
+        if not status or status == StatusCode.STATUS_CANCELED:
             return status, uid, None
         
         byte_data = bytearray(data)
@@ -267,7 +267,7 @@ class SimpleMFRC522(object):
         data = list(bytearray(text, encoding=encoding))
         status, uid, old_data = self.write_bytes(data, terminal_byte=terminal_byte)
         
-        if not status:
+        if not status or status == StatusCode.STATUS_CANCELED:
             return status, uid, None
         
         old_byte_data = bytearray(old_data)


### PR DESCRIPTION
If the statusCode is canceled the bytearray will still be called with a NoneValue

Mayve a better solution would be too keep an eye on data then on the status. Did not grasp all possible cases.
Like if data is compatible to bytearray use it 